### PR TITLE
Improve configuration defaults

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -35,8 +35,7 @@
     },
     "configurationDefaults": {
       "[ifm]": {
-        "editor.autoIndent": "none",
-        "editor.detectIndentation": false,
+        "editor.autoIndent": "keep",
         "editor.wrappingIndent": "indent",
         "editor.tabSize": 2
       }


### PR DESCRIPTION
In `editor.autoIndent`, `keep` causes the editor to reuse the existing
indentation for the following line, which is typically what IFM authors
would want.

So enabling that (together with indentation auto-detect).
