### PR TITLE
Enforce timeout to guard against a runaway `ifm` process

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
       "fileMatch": [
         "*.tmLanguage.json"
       ],
-      "url": "https://raw.githubusercontent.com/Septh/tmlanguage/master/tmLanguage.schema.json"
+      "url": "https://raw.githubusercontent.com/Septh/tmlanguage/master/tmlanguage.json"
     }
   ],
   "search.exclude": {

--- a/extension/src/cli-api.ts
+++ b/extension/src/cli-api.ts
@@ -29,6 +29,7 @@ export interface IfmCli {
 
   runSync(
     argv: string[],
-    input: string
+    input: string,
+    timeout: string | number
   ): { stdout: string; stderr: string; status: number | null; error?: Error };
 }

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -1,0 +1,2 @@
+export const MAX_RUNTIME_MILLIS = 500;
+export const CHANGE_EVENT_THROTTLE_MILLIS: number = 2 * MAX_RUNTIME_MILLIS;

--- a/extension/src/events.ts
+++ b/extension/src/events.ts
@@ -5,6 +5,7 @@ import {
   TextDocumentChangeEvent,
   workspace,
 } from "vscode";
+import { CHANGE_EVENT_THROTTLE_MILLIS } from "./constants";
 
 import {
   excludeIrrelevantChangeEventsByLanguage,
@@ -36,7 +37,11 @@ export const onDidChangeRelevantTextDocument: Event<TextDocument> =
   streamEvents(workspace.onDidChangeTextDocument)
     .through(excludeIrrelevantChangeEventsByScheme)
     .through(excludeIrrelevantChangeEventsByLanguage)
-    .through(throttleEvent, 1000, (e: TextDocumentChangeEvent) => e.document)
+    .through(
+      throttleEvent,
+      CHANGE_EVENT_THROTTLE_MILLIS,
+      (e: TextDocumentChangeEvent) => e.document
+    )
     .through(ignoreIfAlreadyClosed)
     .commit();
 


### PR DESCRIPTION
- Fix schema URL
- Enforce max runtime to guard against runaway `ifm`
